### PR TITLE
Fix build with upcoming GHC 7.4 release

### DIFF
--- a/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/Text/PrettyPrint/ANSI/Leijen.hs
@@ -152,7 +152,7 @@ import Control.Monad (when)
 
 import Data.String (IsString(..))
 import Data.Maybe (isNothing, fromMaybe, catMaybes)
-import Data.Monoid
+import Data.Monoid (Monoid, mappend, mconcat, mempty)
 
 
 infixr 5 </>,<//>,<$>,<$$>

--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 Name:                ansi-wl-pprint
-Version:             0.6.3
+Version:             0.6.4
 Cabal-Version:       >= 1.2
 Category:            User Interfaces, Text
 Synopsis:            The Wadler/Leijen Pretty Printer for colored ANSI terminal output


### PR DESCRIPTION
Hi Max -

These changes keep this package building now that Data.Monoid exports its own definition of `<>`.

If you could do a release quickly, I'd be grateful, as if this package doesn't build, people can't use your test-framework packages.
