### PR TITLE
Add compatibility with base-4.8

### DIFF
--- a/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/Text/PrettyPrint/ANSI/Leijen.hs
@@ -96,7 +96,7 @@ module Text.PrettyPrint.ANSI.Leijen (
    align, hang, indent, encloseSep, list, tupled, semiBraces,
 
    -- * Operators
-   (<+>), (<$>), (</>), (<$$>), (<//>),
+   (<+>), (Text.PrettyPrint.ANSI.Leijen.<$>), (</>), (<$$>), (<//>),
 
    -- * List combinators
    hsep, vsep, fillSep, sep, hcat, vcat, fillCat, cat, punctuate,
@@ -309,7 +309,7 @@ hsep            = fold (<+>)
 --      out
 -- @
 vsep :: [Doc] -> Doc
-vsep            = fold (<$>)
+vsep            = fold (Text.PrettyPrint.ANSI.Leijen.<$>)
 
 -- | The document @(cat xs)@ concatenates all documents @xs@ either
 -- horizontally with @(\<\>)@, if it fits the page, or vertically with

--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 Name:                ansi-wl-pprint
-Version:             0.6.7
+Version:             0.6.7.1
 Cabal-Version:       >= 1.2
 Category:            User Interfaces, Text
 Synopsis:            The Wadler/Leijen Pretty Printer for colored ANSI terminal output

--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 Name:                ansi-wl-pprint
-Version:             0.6.7.1
+Version:             0.6.7.2
 Cabal-Version:       >= 1.2
 Category:            User Interfaces, Text
 Synopsis:            The Wadler/Leijen Pretty Printer for colored ANSI terminal output


### PR DESCRIPTION
Without this, the following compile failure occurs

```
  Text/PrettyPrint/ANSI/Leijen.hs:312:24:
      Ambiguous occurrence ‘<$>’
      It could refer to either ‘Text.PrettyPrint.ANSI.Leijen.<$>’,
                   defined at Text/PrettyPrint/ANSI/Leijen.hs:372:3
                or ‘Prelude.<$>’,
                   imported from ‘Prelude’ at Text/PrettyPrint/ANSI/Leijen.hs:76:8-35
                   (and originally defined in ‘Data.Functor’)
```

as `<$>` is re-exported from `Prelude` starting with base-4.8
